### PR TITLE
Jquery effect callbacks

### DIFF
--- a/Quickstart/src/demos/demos_effects.erl
+++ b/Quickstart/src/demos/demos_effects.erl
@@ -93,6 +93,11 @@ middle() ->
 
         #link { text="Animate - Small Border", actions=Event#event { 
             actions=#animate { options=[{borderWidth, "1px"}] }
+        }},
+        #br{},
+
+        #link { text="Chaining effects - Shake then Puff", actions=Event#event { 
+            actions=#effect { effect=shake, actions=#hide{ effect=puff } }
         }}
     ].
 

--- a/apps/nitrogen/src/actions/action_add_class.erl
+++ b/apps/nitrogen/src/actions/action_add_class.erl
@@ -10,5 +10,6 @@ render_action(Record) ->
     #jquery_effect {
         type=add_class,
         class = Record#add_class.class,
-        speed = Record#add_class.speed
+        speed = Record#add_class.speed,
+        actions = Record#add_class.actions
     }.

--- a/apps/nitrogen/src/actions/action_animate.erl
+++ b/apps/nitrogen/src/actions/action_animate.erl
@@ -11,5 +11,6 @@ render_action(Record) ->
         type=animate,
         options = Record#animate.options,
         speed = Record#animate.speed,
-        easing = Record#animate.easing
+        easing = Record#animate.easing,
+        actions = Record#animate.actions
     }.

--- a/apps/nitrogen/src/actions/action_appear.erl
+++ b/apps/nitrogen/src/actions/action_appear.erl
@@ -9,5 +9,6 @@
 render_action(Record) ->
     #jquery_effect {
         type=appear,
-        speed = Record#appear.speed
+        speed = Record#appear.speed,
+        actions = Record#appear.actions
     }.

--- a/apps/nitrogen/src/actions/action_effect.erl
+++ b/apps/nitrogen/src/actions/action_effect.erl
@@ -13,5 +13,6 @@ render_action(Record) ->
         target = Record#effect.target,
         effect = Record#effect.effect,
         options = Record#effect.options,
-        speed = Record#effect.speed
+        speed = Record#effect.speed,
+        actions = Record#effect.actions
     }.

--- a/apps/nitrogen/src/actions/action_fade.erl
+++ b/apps/nitrogen/src/actions/action_fade.erl
@@ -9,5 +9,6 @@
 render_action(Record) ->
     #jquery_effect {
         type=fade,
-        speed = Record#fade.speed
+        speed = Record#fade.speed,
+        actions = Record#fade.actions
     }.

--- a/apps/nitrogen/src/actions/action_hide.erl
+++ b/apps/nitrogen/src/actions/action_hide.erl
@@ -11,5 +11,6 @@ render_action(Record) ->
         type=hide,
         effect = Record#hide.effect,
         options = Record#hide.options,
-        speed = Record#hide.speed
+        speed = Record#hide.speed,
+        actions = Record#hide.actions
     }.

--- a/apps/nitrogen/src/actions/action_jquery_effect.erl
+++ b/apps/nitrogen/src/actions/action_jquery_effect.erl
@@ -13,22 +13,28 @@ render_action(Record) ->
     Options = options_to_js(Record#jquery_effect.options),
     Class = Record#jquery_effect.class,
     Easing = Record#jquery_effect.easing,
+    Actions = case Record#jquery_effect.actions of
+        undefined ->
+            "null";
+        Actions1 ->
+            ["function() {", Actions1, "}"]
+    end,
 
     Script = case Record#jquery_effect.type of
-        'show' when Effect==none -> wf:f("show();");
-        'hide' when Effect==none -> wf:f("hide();");
-        'toggle' when Effect==none -> wf:f("toggle();");
-        'appear' -> wf:f("fadeIn(~p);", [Speed]);
-        'fade'   -> wf:f("fadeOut(~p);", [Speed]);
-        'show'   -> wf:f("show('~s', ~s, ~p);",   [Effect, Options, Speed]);
-        'hide'   -> wf:f("hide('~s', ~s, ~p);",   [Effect, Options, Speed]);
-        'effect' -> wf:f("effect('~s', ~s, ~p);", [Effect, Options, Speed]);
-        'toggle' -> wf:f("toggle('~s', ~s, ~p);", [Effect, Options, Speed]);
-        'add_class'    -> wf:f("addClass('~s', ~p);", [Class, Speed]);
-        'remove_class' -> wf:f("removeClass('~s', ~p);", [Class, Speed]);
-        'animate' -> wf:f("animate(~s, ~p, '~s');", [Options, Speed, Easing])
+        'show' when Effect==none -> ["show(", Actions, ");"];
+        'hide' when Effect==none -> ["hide(", Actions, ");"];
+        'toggle' when Effect==none -> ["toggle(", Actions, ");"];
+        'appear' -> [wf:f("fadeIn(~p, ", [Speed]), Actions, ");"];
+        'fade'   -> [wf:f("fadeOut(~p, ", [Speed]), Actions, ");"];
+        'show'   -> [wf:f("show('~s', ~s, ~p, ", [Effect, Options, Speed]), Actions, ");"];
+        'hide'   -> [wf:f("hide('~s', ~s, ~p, ", [Effect, Options, Speed]), Actions, ");"];
+        'effect' -> [wf:f("effect('~s', ~s, ~p, ", [Effect, Options, Speed]), Actions, ");"];
+        'toggle' -> [wf:f("toggle('~s', ~s, ~p, ", [Effect, Options, Speed]), Actions, ");"];
+        'add_class'    -> [wf:f("addClass('~s', ~p, ", [Class, Speed]), Actions, ");"];
+        'remove_class' -> [wf:f("removeClass('~s', ~p, ", [Class, Speed]), Actions, ");"];
+        'animate' -> [wf:f("animate(~s, ~p, '~s', ", [Options, Speed, Easing]), Actions, ");"]
     end,
-    wf:f("objs('~s').~s", [Target, Script]).
+    [wf:f("objs('~s').", [Target]), Script].
 
 
 %% Options is a list of {Key,Value} tuples	

--- a/apps/nitrogen/src/actions/action_remove_class.erl
+++ b/apps/nitrogen/src/actions/action_remove_class.erl
@@ -10,5 +10,6 @@ render_action(Record) ->
     #jquery_effect {
         type=remove_class,
         class = Record#remove_class.class,
-        speed = Record#remove_class.speed
+        speed = Record#remove_class.speed,
+        actions = Record#remove_class.actions
     }.

--- a/apps/nitrogen/src/actions/action_show.erl
+++ b/apps/nitrogen/src/actions/action_show.erl
@@ -11,5 +11,6 @@ render_action(Record) ->
         type=show,
         effect = Record#show.effect,
         options = Record#show.options,
-        speed = Record#show.speed
+        speed = Record#show.speed,
+        actions = Record#show.actions
     }.

--- a/apps/nitrogen/src/actions/action_toggle.erl
+++ b/apps/nitrogen/src/actions/action_toggle.erl
@@ -11,5 +11,6 @@ render_action(Record) ->
         type=toggle,
         effect = Record#toggle.effect,
         options = Record#toggle.options,
-        speed = Record#toggle.speed
+        speed = Record#toggle.speed,
+        actions = Record#toggle.actions
     }.


### PR DESCRIPTION
By providing actions to jquery effects, they will be triggered when the effect has finished. This can be useful in various scenarios, such as several effects one after the other (as in the example added to the demo page), or for example removing an element after fading out: #fade{actions = #update{type = remove}}.
