### PR TITLE
Don't extend $params with form and event context data.

### DIFF
--- a/apps/nitrogen/www/nitrogen.js
+++ b/apps/nitrogen/www/nitrogen.js
@@ -129,9 +129,11 @@ NitrogenClass.prototype.$do_event = function(validationGroup, eventContext, extr
         this.$event_is_running = false;
         return;
     }
+
     // Assemble other parameters... 
-    var params = jQuery.extend(n.$params, validationParams, { eventContext: eventContext });
-    
+    var params = new Object;
+    jQuery.extend(params, n.$params, validationParams, { eventContext: eventContext });
+
     jQuery.ajax({ 
         url: this.$url,
         type:'post',


### PR DESCRIPTION
Extending $params (in NitrogenClass) with validationParams causes all form data ever transmitted to be retransmitted every time an event is run. For example, currently on master HEAD:
1. Adding a form via #update{...}
2. Event callback (Nitrogenclass.do_event) transmits form data
3. Form is removed via #update{...}
4. Adding the same (or almost the same) form via #update{...}
5. Event callback again transmits both all the form data from (2) as well as the one from the new form.
6. In the erlang code, calling wf:q(...) for some element in the form results in an error, since get_values don't know which of the values to choose.

The values are not overwritten (considering that it's a map) because at some plae in the dom tree, the id differ.

The form data is retransmitted because it's added to $params, which then is reused in the next event.
