### PR TITLE
Dont renormalize ids while rendering elements

### DIFF
--- a/apps/nitrogen/src/lib/wf_render_elements.erl
+++ b/apps/nitrogen/src/lib/wf_render_elements.erl
@@ -114,6 +114,7 @@ call_element_render(Module, Element) ->
 
 normalize_id(ID) -> 
     case wf:to_string_list(ID) of
+        [".wfid_" ++ _] = [NormalizedID] -> NormalizedID;
         ["page"] -> ".page";
         [NewID]  -> ".wfid_" ++ NewID
     end.


### PR DESCRIPTION
When an element #foo{id = Id, ...} is rendered as #bar{id = Id, ...}, the #bar.id will be "normalized" twice, resulting in, when the original Id is my_id, wfid_wfid_myid. This patch avoids this by avoiding adding the wfid_ prefix to an id wich such a prefix already in place.
