### PR TITLE
Please add emacs nitrogen mode hint to generic index.erl

### DIFF
--- a/rel/overlay/site/src/index.erl
+++ b/rel/overlay/site/src/index.erl
@@ -1,3 +1,4 @@
+%% -*- mode: nitrogen -*-
 -module (index).
 -compile(export_all).
 -include_lib("nitrogen/include/wf.hrl").


### PR DESCRIPTION
I do a lot of erlang work outside of Nitrogen so I use auto-mode-alist to switch to erlang-mode when editing .erl files. To automatically use nitrogen-mode when editing Nitrogen .erl files, I add a comment with "mode: nitrogen" at the top of the file. This might help others.
