### PR TITLE
Fix objs when given a dom id

### DIFF
--- a/apps/nitrogen/www/nitrogen.js
+++ b/apps/nitrogen/www/nitrogen.js
@@ -226,7 +226,7 @@ function objs(path, anchor) {
     path = path.replace(/\bme\b/g, anchor);
 
     // If this is a single word, then rewrite it to a Nitrogen element id.
-    if (path.indexOf(" ") == -1 && path.indexOf(".") == -1) {
+    if (path.indexOf(" ") == -1 && path.indexOf(".") == -1 && path.indexOf("#") == -1) {
         var results = objs(".wfid_" + path, anchor);
         
         // If we found results, then return them...


### PR DESCRIPTION
Without this fix wf:update("#id", Something) would try to add Something to what jQuery(".wfid_#id") would find. This small fix avoids adding the .wfid_ prefix not only when there is a "." or a " " in the path, but also a "#".
