### PR TITLE
Interface to get scheme used in request

### DIFF
--- a/apps/simple_bridge/src/inets_bridge_modules/inets_request_bridge.erl
+++ b/apps/simple_bridge/src/inets_bridge_modules/inets_request_bridge.erl
@@ -8,7 +8,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    request_method/1, path/1, uri/1, scheme/1,
     peer_ip/1, peer_port/1,
     headers/1, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -28,6 +28,9 @@ path(Req) ->
 
 uri(Req) ->
     Req#mod.request_uri.
+
+scheme(_Req) ->
+    undefined.
 
 peer_ip(Req) -> 
     Socket = Req#mod.socket,

--- a/apps/simple_bridge/src/misultin_bridge_modules/misultin_request_bridge.erl
+++ b/apps/simple_bridge/src/misultin_bridge_modules/misultin_request_bridge.erl
@@ -3,7 +3,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    request_method/1, path/1, uri/1, scheme/1,
     peer_ip/1, peer_port/1,
     headers/1, cookies/1,
     query_params/1, post_params/1, request_body/1
@@ -26,6 +26,9 @@ path(Req) ->
 
 uri(Req) ->
     Req:get(uri).
+
+scheme(_Req) ->
+    undefined.
 
 peer_ip(Req) -> 
     Req:get(peer_addr).

--- a/apps/simple_bridge/src/mochiweb_bridge_modules/mochiweb_request_bridge.erl
+++ b/apps/simple_bridge/src/mochiweb_bridge_modules/mochiweb_request_bridge.erl
@@ -7,7 +7,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    request_method/1, path/1, uri/1, scheme/1,
     peer_ip/1, peer_port/1,
     headers/1, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -27,6 +27,9 @@ path({Req, _DocRoot}) ->
 
 uri({Req, _DocRoot}) ->
     Req:get(raw_path).
+
+scheme(_Req) ->
+    undefined.
 
 peer_ip({Req, _DocRoot}) -> 
     Socket = Req:get(socket),

--- a/apps/simple_bridge/src/simple_bridge_request.erl
+++ b/apps/simple_bridge/src/simple_bridge_request.erl
@@ -37,6 +37,7 @@ behaviour_info(callbacks) -> [
     {request_method, 1}, % GET, POST, etc.
     {uri, 1},            % The uri (path and querystring)
     {path, 1},           % Just the path. (http://server.com/<PATH>?querystring)
+    {scheme, 1},         % http, https, spdy, gopher, ..., undefined
 
     {headers, 1},        % Return a proplist of headers, key and value are strings.
     {cookies, 1},        % Return a proplist of cookies, key and value are strings.

--- a/apps/simple_bridge/src/simple_bridge_request_wrapper.erl
+++ b/apps/simple_bridge/src/simple_bridge_request_wrapper.erl
@@ -15,6 +15,7 @@ set_error(Error1) ->
 request_method() -> Mod:request_method(Req).
 path() -> Mod:path(Req).
 uri() -> Mod:uri(Req).
+scheme() -> Mod:scheme(Req).
 
 peer_ip() -> Mod:peer_ip(Req).
 peer_port() -> Mod:peer_port(Req).

--- a/apps/simple_bridge/src/webmachine_bridge_modules/webmachine_request_bridge.erl
+++ b/apps/simple_bridge/src/webmachine_bridge_modules/webmachine_request_bridge.erl
@@ -11,6 +11,7 @@
     request_method/1, 
     path/1, 
     uri/1,
+    scheme/1,
     peer_ip/1, 
     peer_port/1,
     headers/1, 
@@ -35,6 +36,9 @@ uri(Req) ->
     RawPath = wrq:raw_path(Req),
     {_, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
     QueryString.
+
+scheme(_Req) ->
+    undefined.
 
 peer_ip(_Req) -> 
     throw(unsupported).

--- a/apps/simple_bridge/src/yaws_bridge_modules/yaws_request_bridge.erl
+++ b/apps/simple_bridge/src/yaws_bridge_modules/yaws_request_bridge.erl
@@ -7,7 +7,7 @@
 -include_lib ("simple_bridge.hrl").
 -export ([
     init/1,
-    request_method/1, path/1, uri/1,
+    request_method/1, path/1, uri/1, scheme/1,
     peer_ip/1, peer_port/1,
     headers/1, cookie/2, cookies/1,
     query_params/1, post_params/1, request_body/1,
@@ -27,6 +27,13 @@ uri(Arg) ->
     Req = Arg#arg.req,
     {abs_path, Path} = Req#http_request.path,
     Path.
+
+scheme(Arg) ->
+    case {Arg#arg.req, Arg#arg.clisock} of
+        {#http_request{}, {sslsocket, _, _}} -> https;
+        {#http_request{}, _}                 -> http;
+        _                                    -> undefined
+    end.
 
 peer_ip(Arg) -> 
     Socket = socket(Arg),


### PR DESCRIPTION
It could be useful to know whether for example https or http (or any other protocol) were used in the request to nitrogen. To know this, there needs to be an interface for this in simple_bridge. This commit contains a proposed interface, and an implementation in yaws. If interested, I could help out in implementing support in the other bridge implementations as well.
