### PR TITLE
Travis-CI support added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: erlang
+notifications:
+  email: false
+otp_release:
+  - R14B03
+  - R14B02
+  - R14B01


### PR DESCRIPTION
Hi Guys,

Travis-CI support for Erlang is live. You can use this .travis.yml and add Nitrogen to http://travis-ci.org (for docs about this process, see http://about.travis-ci.org/docs/user/getting-started/). An example build output can be found here: http://travis-ci.org/#!/wardbekker/nitrogen/builds/83584

Let me know if you have any questions.
