### PR TITLE
increase default max POST chunk size for Yaws

### DIFF
--- a/rel/overlay/yaws/etc/yaws.conf
+++ b/rel/overlay/yaws/etc/yaws.conf
@@ -7,6 +7,12 @@ logdir = ./log
     #the static code to be served directly by yaws is found in ./site/static
     docroot = ./site/static
 
+    # increase the yaws max POST chunk size from its default of 10240
+    # bytes. POST data larger than this currently breaks the simple_bridge
+    # yaws integration -- this is a workaround that makes it less likely
+    # users will hit the problem while simple_bridge is being fixed.
+    partial_post_size = 2048000
+
     # tell yaws to pass control to the nitrogen_yaws module 
     # (specifically nitrogen_yaws:out/1) for all requests except for any request
     # that starts with "images/", "nitrogen/", "css/", or "/js".


### PR DESCRIPTION
The default max chunk size for POST data for Yaws before it breaks the data
into chunks is 10240 bytes. Increase this to 2048000 for now because
currently simple_bridge doesn't handle the chunking Yaws does for POST data
that exceeds the default size. Note that this doesn't fix the problem, but
is just an workaround that makes it less likely users will hit it.

Unfortunately I don't have an automated test for this, but I verified it
manually. I'd rather put testing effort into a proper fix in simple_bridge.
