### PR TITLE
check for bash in other locations besides /bin/

### DIFF
--- a/rel/overlay/common/bin/dev
+++ b/rel/overlay/common/bin/dev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
 


### PR DESCRIPTION
This allows bin/dev to be used on systems like OpenBSD which have bash installed to /usr/local/bin
