### PR TITLE
Avoids errors with update-deps

### DIFF
--- a/rel/overlay/cowboy.deps
+++ b/rel/overlay/cowboy.deps
@@ -1,3 +1,1 @@
     {cowboy,        ".*",   {git, "git://github.com/extend/cowboy",         {tag, "0.8.6"}}},
-    {ranch,         ".*",   {git, "git://github.com/extend/ranch",          {tag, "0.8.4"}}},
-    {mimetypes,     ".*",   {git, "git://github.com/spawngrid/mimetypes",   {branch, master}}},


### PR DESCRIPTION
This change avoids errors updating ranch and mimetypes when is executed 'update-deps'. This error is generated because both are already dependencies of cowboy and simple-bridge respectively.

Jesse, thanks for your help.
