### PR TITLE
Fixed a small error in build-ini.bat file which was preventing startup on Windows

### DIFF
--- a/rel/overlay/win/files/build-ini.bat
+++ b/rel/overlay/win/files/build-ini.bat
@@ -11,7 +11,7 @@ REM Further, if you were to move the nitrogen directory to a different location,
 REM the previously generated INI files would again be pointing at the wrong
 REM location, so we rebuild it every time before we compile.
 
-dir /X /B ERTS-*>>%TEMP%\erts.txt
+dir /X /B ERTS-*>%TEMP%\erts.txt
 set /p ERTS=<%TEMP%\erts.txt
 
 set INIFILE=%ERTS%\bin\erl.ini


### PR DESCRIPTION
The script which is trying to determine current ERTS version appends to the temp file instead of overwriting it. It works the first time you run it, but if ERTS version changes, it will keep assigning the first line from that file (which contains ERTS version as of the first invocation of the script). Patch tested on Windows 7. 
