### PR TITLE
Avoid behaviour simple_bridge_handler warning

### DIFF
--- a/rel/overlay/rebar.config.src
+++ b/rel/overlay/rebar.config.src
@@ -21,14 +21,14 @@
 
     %% Uncomment the following lines and comment the bottom lines with specific
     %% tags to always pull the latest versions
+    {simple_bridge, ".*",   {git, "git://github.com/nitrogen/simple_bridge",{branch, master}}},
     {nitrogen_core, ".*",   {git, "git://github.com/nitrogen/nitrogen_core",{branch, master}}},
     {nprocreg,      ".*",   {git, "git://github.com/nitrogen/nprocreg",     {branch, master}}},
-    {simple_bridge, ".*",   {git, "git://github.com/nitrogen/simple_bridge",{branch, master}}},
     {sync,          ".*",   {git, "git://github.com/rustyio/sync",          {branch, master}}}
 
     %% Get specific tagged version
-    %{nitrogen_core, ".*",   {git, "git://github.com/nitrogen/nitrogen_core",{tag, "v2.3.0"}}},
-    %{nprocreg,      ".*",   {git, "git://github.com/nitrogen/nprocreg",     {tag, "v0.2.1"}}},
     %{simple_bridge, ".*",   {git, "git://github.com/nitrogen/simple_bridge",{tag, "v2.0.0"}}},
+    %{nitrogen_core, ".*",   {git, "git://github.com/nitrogen/nitrogen_core",{tag, "v2.3.0"}}},
+    %{nprocreg,      ".*",   {git, "git://github.com/nitrogen/nprocreg",     {tag, "v0.2.1"}}},    
     %{sync,          ".*",   {git, "git://github.com/rustyio/sync",          {tag, "1366fdc"}}}
 ]}.


### PR DESCRIPTION
lib/nitrogen_core/src/nitrogen.erl:8: Warning: behaviour simple_bridge_handler undefined

Not much to explain :) just changing the order of repos to compile simple_bridge first.

P.S. Great work last night!!! Thanks.
