### PR TITLE
modified build-ini.bat to fix an issue with how ERTS path is determined 

### DIFF
--- a/rel/overlay/win/files/build-ini.bat
+++ b/rel/overlay/win/files/build-ini.bat
@@ -11,8 +11,7 @@ REM Further, if you were to move the nitrogen directory to a different location,
 REM the previously generated INI files would again be pointing at the wrong
 REM location, so we rebuild it every time before we compile.
 
-dir /X /B ERTS-*>>%TEMP%\erts.txt
-set /p ERTS=<%TEMP%\erts.txt
+for /f "tokens=1" %%i in ('dir /x /b erts-*') do SET ERTS=%%i
 
 set INIFILE=%ERTS%\bin\erl.ini
 set PWD=%cd:\=\\%


### PR DESCRIPTION
As discussed in PR https://github.com/nitrogen/nitrogen/pull/77 this is an alternative way to determine ERTS path on windows without the temp files. Tested on XP and Win7.
