### PR TITLE
updated rel/overlay/yaws.deps to allow Erlang 18 builds with yaws

### DIFF
--- a/rel/overlay/yaws.deps
+++ b/rel/overlay/yaws.deps
@@ -1,1 +1,1 @@
-    {yaws, "1.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-1.98"}}},
+    {yaws, "2.*", {git, "git://github.com/klacke/yaws",	{tag, "yaws-2.0.2"}}},


### PR DESCRIPTION
`make rel_yaws` failed for me with version 1.98 of yaws. After updating to yaws 2.0.2 everything worked fine again. I tested this change with Erlang 17 and 18.