### PR TITLE
fixed .travis.zml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ otp_release:
   - R15B02
   - R15B01
   - R15B
-before_script: "sudo apt-get --yes --force-yes install libpam0g-dev"
+before_script: "sudo apt-get --yes --force-yes install libpam-runtime"


### PR DESCRIPTION
Travis.ci is was failing with 
```
Package libpam0g-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libpam-runtime
E: Package 'libpam0g-dev' has no installation candidate
The command "sudo apt-get --yes --force-yes install libpam0g-dev" failed and exited with 100 during .
Your build has been stopped.
```

so i preplaced libpam0g-dev with libpam-runtime.