### PR TITLE
Erlang 21 Support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {sub_dirs, ["rel"]}.
 
-{require_otp_vsn, "R15|R16|17|18|19|20"}.
+{require_otp_vsn, "R15|R16|17|18|19|20|21"}.
 
 {cover_enabled, true}.
 


### PR DESCRIPTION
Only updated supported Erlang release level
I have tested both make slim_cowboy and make rel_cowboy without any issues on Ubuntu 18.04
