### PR TITLE
Infer erlang version (when asdf)

### DIFF
--- a/rel/overlay/common/bin/nitrogen
+++ b/rel/overlay/common/bin/nitrogen
@@ -112,8 +112,9 @@ elif [ "$RUNNER_SCRIPT_DATA" = "slim" ]; then
     SYSTEM_HOME_BASENAME=`basename "$SYSTEM_HOME_BIN"`
 
     if [ "$SYSTEM_HOME_BASENAME" = "shims" ]; then
-        # this is asdf, so let's find ASDF's installation
-	ROOTDIR="$SYSTEM_HOME_BIN/../installs/erlang/$ASDF_ERLANG_VERSION";
+      # this is asdf, so let's find ASDF's installation
+      CURRENT_ERLANG_VERSION="${ASDF_ERLANG_VERSION:-$(asdf current erlang | awk '{print $2}')}"
+      ROOTDIR="$SYSTEM_HOME_BIN/../installs/erlang/$CURRENT_ERLANG_VERSION";
     elif [ -d "$SYSTEM_HOME_BIN/../lib/erlang" ]; then
 	## This is a check for OSX using the Erlang Solutions installer
         ROOTDIR=$SYSTEM_HOME_BIN/../lib/erlang


### PR DESCRIPTION
We can infer the current version of erlang using `asdf current erlang` if the env variable `ASDF_ERLANG_VERSION` is not set.