### PR TITLE
tweak for elixir mix umbrella project use

### DIFF
--- a/templates/common/copy_static.escript
+++ b/templates/common/copy_static.escript
@@ -19,26 +19,61 @@ main([Action]) when Action=="copy"; Action=="link" ->
         "_checkouts/nitrogen_core/www", %% old loc, but let's check
         "_checkouts/nitrogen_core/priv/www",
         "_build/default/checkouts/nitrogen_core/priv/www",
-        "_build/default/lib/nitrogen_core/priv/www"
+        "_build/default/lib/nitrogen_core/priv/www",
+        %% account for the possibility this is a mix umbrella app;
+        %% dependencies are in <base>/deps/.  mix will execute rebar3
+        %% from the nitrogen base directory however, so the relative
+        %% path works here.
+        "../../deps/nitrogen_core/www"
     ],
     Src = find_first_loc(PossibleLocations),
     Dest = "priv/static/nitrogen",
-  
-    %% These need to be changed such that they don't rely on linux tools and just use
-    %% file:copy and file:make_symlink
-    cmd("rm -fr " ++ Dest),
+
+    io:format("Removing existing assets directory ~s~n", [Dest]),
+    ok = case file:del_dir_r(Dest) of
+        ok -> ok;
+        {error, enoent} -> ok;
+        Err -> Err
+    end,
+
     case Action of
         "copy" ->
-            cmd("mkdir -p " ++ Dest),
-            cmd("cp -r " ++ Src ++ "/* " ++ Dest);
+            io:format("Creating assets directory ~s~n", [Dest]),
+            ok = filelib:ensure_path(Dest),
+            rcopy(filelib:wildcard("**", Src), Src, Dest);
         "link" ->
-            cmd("ln -s `pwd`/" ++ Src ++ " " ++ Dest)
-    end.
-        
+            {ok, Cwd} = file:get_cwd(),
+            AbsSrc = filename:join(Cwd, Src),
+            io:format("Linking assets to ~s~n", [Dest]),
+            ok = file:make_symlink(AbsSrc, Dest)
+    end,
 
-cmd(Cmd) ->
-    io:format("Running: ~s~n", [Cmd]),
-    os:cmd(Cmd).
+    %% in a mix umbrella app, we want all the nitro priv assets in
+    %% <base>/priv.  in a more perfect world, all of the assets might
+    %% be in a single subdirectory (thus avoiding the possibility of
+    %% clobbering existing <base>/priv files); that wouldn't jive with
+    %% how nitro finds its stuff though and changing that would negate
+    %% backwards compatibility.
+    case string:find(Src, "../../deps") of
+        nomatch -> ok;
+        _ ->
+            io:format("Copying assets to umbrella base privdir.~n"),
+            BasePriv = "../../priv",
+            NitroPriv = "priv",
+            ok = filelib:ensure_path(BasePriv),
+            rcopy(filelib:wildcard("**", NitroPriv), NitroPriv, BasePriv)
+    end.
+
+rcopy([], _SourceDir, _DestDir) ->
+    ok;
+rcopy([F|T], SourceDir, DestDir) ->
+    S = filename:join(SourceDir, F),
+    D = filename:join(DestDir, F),
+    case filelib:is_dir(S) of
+        true  -> file:make_dir(D);
+        false -> file:copy(S, D)
+    end,
+    rcopy(T, SourceDir, DestDir).
 
 
 find_first_loc([]) ->
@@ -48,4 +83,3 @@ find_first_loc([H|T]) ->
         true -> H;
         false -> find_first_loc(T)
     end.
-    


### PR DESCRIPTION
Hi -- I'm not sure if this is of interest but I figured I'd send it along.  I've got a project where Nitrogen is one component of an Elixir project.  (For reasons relating to dependency management it's easier to build Erlang with mix than Elixir with rebar; the 3rd party libs I need are all Elixir.)  After some futzing I've managed to slot Nitrogen in nicely though[*].  There are a few mismatches in how things are structured: the privdir and asset management is the first of them.  I've made a couple of tweaks to the escript to account for how dependencies and the privdir are managed in mix umbrella projects that I think are compatible with "normal" Erlang deployments.  (And converted the shell commands to Erlang in passing, as per the note in the code.)  If a Docker container with a skeleton would be helpful for testing, that wouldn't be hard to provide.

If this use case is of interest, I'll make an attempt to do a similar bit of work with the assemble_config.escript.  I've converted the configuration into Elixir by hand (it's the only other bit of work I had to do to get things running) but doing that by script doesn't seem crazy hard although might require a manual step to include the resulting config file into the Elixir project's configuration.  

The rebar3 work you've done is pretty great.  Keeping everything backward compatible cannot have been trivial!  Thanks for the work: I've been slicing and dicing Nitrogen to release with rebar3 for a while now and it's awfully nice to just use Nitrogen off the shelf.

[*] I gave the Phoenix stuff a reasonable shot but damn, there's just so much magic involved.  Good on 'em for making the simple cases simple but if you're not sticking to Phoenix's idea of what a "web app" should be, it's mighty convoluted. 