### PR TITLE
Update Makefile to add ebin folder

### DIFF
--- a/templates/common/Makefile
+++ b/templates/common/Makefile
@@ -106,7 +106,7 @@ site/include:
 
 site/ebin:
 	@(mkdir -p _build/default/lib/{{name}}/ebin)
-	@(ln -s ../_build/default/lib/nb/ebin site/ebin)
+	@(ln -s ../_build/default/lib/{{name}}/ebin site/ebin)
 
 priv/static/nitrogen: link-static
 

--- a/templates/common/Makefile
+++ b/templates/common/Makefile
@@ -86,7 +86,7 @@ _build: deps
 plugins: _build
 	@(escript do-plugins.escript)
 
-rebar2_links: site site/static site/src site/templates site/include
+rebar2_links: site site/static site/src site/templates site/include site/ebin
 
 site:
 	@echo Making Nitrogen 2 compatible directory structure symlinks
@@ -103,6 +103,10 @@ site/templates:
 
 site/include:
 	@(ln -s ../include site/include)
+
+site/ebin:
+	@(mkdir -p _build/default/lib/{{name}}/ebin)
+	@(ln -s ../_build/default/lib/nb/ebin site/ebin)
 
 priv/static/nitrogen: link-static
 


### PR DESCRIPTION
Updated the makefile to re-introduce the site/ebin symbolic link to the _build/default/lib/{{name}}/ebin folder + create that folder with appropriate project name at project creation time.

Tested locally to create a new project, no errors with project make or launching nitrogen.

This was an issue found while working my way through Build it with Nitrogen, Listing 3.18 fails as the ebin folder isn't present to execute rr(visitors_db).