### PR TITLE
fix(mac): tweaks to fix makefile on macos

### DIFF
--- a/install_templates
+++ b/install_templates
@@ -1,7 +1,7 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 echo "Determining rebar3 Templates directory"
-TEMP_PATH=$(./rebar3 dirs template_dir)
+TEMP_PATH=$(./rebar3 dirs template_dir || rebar3 dirs template_dir)
 TEMP_PATH=$(echo -n "$TEMP_PATH")
 echo "Template Path = $TEMP_PATH"
 

--- a/support/helper_script/nitrogen.sh
+++ b/support/helper_script/nitrogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Nitrogen initialization script for *nix OSes
 #
 # Public Domain

--- a/templates/common/in-git.sh
+++ b/templates/common/in-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if git rev-parse --git-dir >/dev/null 2>&1; then
 	echo "yes"

--- a/templates/common/upgrade_release.sh
+++ b/templates/common/upgrade_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
## Problem being addressed

**Issue:** https://github.com/nitrogen/nitrogen/issues/149

Fixes to get the Makefile scripts to work on MacOS.

On recent versions of MacOS, bash isn't at `/usr/bin/bash` which causes `install_templates` to fail. Additionally, on MacOS running `./rebar3 dirs template_dir` returns an empty string, which causes the later steps to fail. However, running `rebar3 dirs template_dir` does return the correct path.

## Changes

* Switched from `/usr/bin/bash` and `/bin/bash` to `/usr/bin/env bash` to use whichever bash appears in the PATH.
* Added fallback bash command for rebar to use rebar3 on PATH if the local rebar3 isn't working

Operating systems and architectures tested on:
* MacOS Sonoma (14) x86_64
* MacOS Sonoma (14) ARM
* Pop-OS! 22.04 (Ubuntu based) x86_64
