### PR TITLE
Fix(asdf): correctly resolve Erlang version

### DIFF
--- a/templates/common/bin/nitrogen.old
+++ b/templates/common/bin/nitrogen.old
@@ -113,7 +113,7 @@ elif [ "$RUNNER_SCRIPT_DATA" = "slim" ]; then
 
     if [ "$SYSTEM_HOME_BASENAME" = "shims" ]; then
       # this is asdf, so let's find ASDF's installation
-      CURRENT_ERLANG_VERSION="${ASDF_ERLANG_VERSION:-$(asdf current erlang | awk '{print $2}')}"
+      CURRENT_ERLANG_VERSION="${ASDF_ERLANG_VERSION:-$(asdf current erlang | grep '^erlang' | awk '{print $2}')}"
       ROOTDIR="$SYSTEM_HOME_BIN/../installs/erlang/$CURRENT_ERLANG_VERSION";
     elif [ -d "$SYSTEM_HOME_BIN/../lib/erlang" ]; then
 	## This is a check for OSX using the Erlang Solutions installer


### PR DESCRIPTION
Newer versions of asdf (e.g. v0.16.7) include a header row in `asdf current erlang` output, which broke version parsing in the `nitrogen` script. This change updates the script to extract the actual Erlang version, restoring compatibility.

### asdf version
v0.16.7
### `asdf current erlang` command output
```shell
Name            Version         Source                               Installed
erlang          25.3.2.21       /home/user/code/.tool-versions true
```

### Error when starting nitrogen

```shell
Exec: /home/user/.asdf/shims/../installs/erlang/Version
25.3.2.21/erts-13.2.2.16/bin/erlexec -boot_var RELTOOL_EXT_LIB /home/user/code/myapp/lib -sasl releases_dir "/home/user/code/myapp/releases" -boot /home/user/code/myapp/releases/2.4.0/nitrogen -mode interactive  -config /home/user/code/myapp/etc/app.config -config /home/user/code/myapp/etc/simple_bridge.config -config /home/user/code/myapp/etc/sync.config -args_file /home/user/code/myapp/etc/vm.args -- console
Root: /home/user/.asdf/shims/../installs/erlang/Version
25.3.2.21
bin/nitrogen: 307: exec: /home/user/.asdf/shims/../installs/erlang/Version: not found
```